### PR TITLE
Fix error output was missing

### DIFF
--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -73,7 +73,7 @@ class Shell:
             while True:
                 output = proc.stdout.readline()
                 err = proc.stderr.read()
-                if len(err) and not suppress_message:
+                if err and not suppress_message:
                     self.error(err.decode("utf-8", errors="ignore"))
                 if len(output) == 0 and proc.poll() is not None:
                     break


### PR DESCRIPTION
So this was part of why it seemed to appear stuck. Errors were not being shown. Also, this fixes an issue if you did a control+c in the middle of the shell running, it sometimes would mess up the terminal.