### PR TITLE
Add Raspberry Pi OS 64-bit Detection

### DIFF
--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -442,6 +442,13 @@ class Shell:
         return platform.machine() == "armv8l"
 
     @staticmethod
+    def is_arm64():
+        """
+        Check if Platform.machine() returns ARM 64
+        """
+        return platform.machine() == "aarch64"
+
+    @staticmethod
     def get_arch():
         """Return a string containing the architecture"""
         return platform.machine()
@@ -470,6 +477,8 @@ class Shell:
                     for opsys in os_releases:
                         if opsys in release_file:
                             release = opsys
+                if release == "Debian" and os.path.exists("/etc/rpi-issue"):
+                    release = "Raspbian"
         if os.path.isdir(os.path.expanduser("~/.kano-settings")) or os.path.isdir(
             os.path.expanduser("~/.kanoprofile")
         ):

--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -88,7 +88,7 @@ class Shell:
                     if not suppress_message:
                         self.info(decoded_output)
                     full_output += decoded_output
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             pass
         finally:
             sys.stdout = original_stdout
@@ -294,7 +294,7 @@ class Shell:
 
         if self.exists(location) and not self.isdir(location):
             if multi_line:
-                with open(location, "r+") as file:
+                with open(location, "r+", encoding="utf-8") as file:
                     if re.search(pattern, file.read(), flags=re.DOTALL):
                         found = True
             else:
@@ -315,7 +315,7 @@ class Shell:
         if self.pattern_search(location, pattern, multi_line):
             if multi_line:
                 regex = re.compile(pattern, flags=re.DOTALL)
-                with open(location, "r+") as file:
+                with open(location, "r+", encoding="utf-8") as file:
                     data = file.read()
                     file.seek(0)
                     file.write(regex.sub(replace, data))
@@ -397,7 +397,7 @@ class Shell:
             content = "\n" + content
         else:
             mode = "w"
-        with open(self.path(path), mode) as service_file:
+        with open(self.path(path), mode, encoding="utf-8") as service_file:
             service_file.write(content)
 
     @staticmethod
@@ -468,11 +468,11 @@ class Shell:
         )
         release = None
         if os.path.exists("/etc/os-release"):
-            with open("/etc/os-release") as f:
+            with open("/etc/os-release", encoding="utf-8") as f:
                 if "Raspbian" in f.read():
                     release = "Raspbian"
             if self.run_command("command -v apt-get", suppress_message=True):
-                with open("/etc/os-release") as f:
+                with open("/etc/os-release", encoding="utf-8") as f:
                     release_file = f.read()
                     for opsys in os_releases:
                         if opsys in release_file:
@@ -495,7 +495,7 @@ class Shell:
             return None
         raspbian_releases = ("buster", "stretch", "jessie", "wheezy")
         if os.path.exists("/etc/os-release"):
-            with open("/etc/os-release") as f:
+            with open("/etc/os-release", encoding="utf-8") as f:
                 release_file = f.read()
                 if "/sid" in release_file:
                     return "unstable"


### PR DESCRIPTION
Raspberry Pi OS 64-bit is almost identical to Debian including the `/etc/os-release` file, making accurate detection quite difficult. I noticed a `rpi-issue` file under `/etc` was the only thing I could find that distinguished it from Debian.