### PR TITLE
Use new platform detect feature to see if board is Pi5

### DIFF
--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -698,6 +698,14 @@ class Shell:
         return detector.board.id
 
     @staticmethod
+    def is_pi5_or_newer():
+        """
+        Use PlatformDetect to check if this is a Raspberry Pi 5 or newer
+        """
+        detector = adafruit_platformdetect.Detector()
+        return detector.board.any_raspberry_pi_5_board
+
+    @staticmethod
     def get_architecture():
         """
         Get the type of Processor


### PR DESCRIPTION
I forgot I had added this and now it's coming in useful. I added it with the intention to make it easy to check if we have newer Pi 5 boards or older boards.