### PR TITLE
Bump reuse-tool pre-commit hook to v6.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v6.2.0
     hooks:
       - id: reuse
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Bumps the `fsfe/reuse-tool` pre-commit hook from **v1.1.2 → v6.2.0** to unblock CI.

### Why

`reuse-tool` v1.x imports `pkg_resources` at startup, which lives inside `setuptools`. Python ≥ 3.12 no longer bundles `setuptools` by default, so on the current GitHub Actions Python runners the hook now crashes at import time with:

```
File ".../reuse/__init__.py", line 15, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```

PR #31 (merged 2025-11) was the last successful run; the runner environment has drifted since.

### Why this specific version

v6.2.0 is what `adafruit/Adafruit_CircuitPython_Display_Text` is currently using on its `main` branch, so it matches a known-good Adafruit reference.

### Scope

Single-line change to `.pre-commit-config.yaml`. Intentionally narrow — a follow-up to migrate the whole config to `ruff` (replacing `black` + `pylint`, matching the CircuitPython-library convention) is planned separately.

### Verification

Ran `pre-commit run --all-files` inside `python:3.11-slim` (the same Python the CI workflow uses):

```
black....................................................................Passed
reuse lint...............................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
pylint (library code)....................................................Passed
pylint (example code)................................(no files to check)Skipped
pylint (test code)...................................(no files to check)Skipped
```
