### PR TITLE
Migrate pre-commit from black + pylint to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,40 +3,19 @@
 # SPDX-License-Identifier: Unlicense
 
 repos:
-  - repo: https://github.com/python/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-  - repo: https://github.com/fsfe/reuse-tool
-    rev: v6.2.0
-    hooks:
-      - id: reuse
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
     hooks:
-      - id: pylint
-        name: pylint (library code)
-        types: [python]
-        args:
-          - --disable=consider-using-f-string
-        exclude: "^(docs/|examples/|tests/|setup.py$)"
-      - id: pylint
-        name: pylint (example code)
-        description: Run pylint rules on "examples/*.py" files
-        types: [python]
-        files: "^examples/"
-        args:
-          - --disable=missing-docstring,invalid-name,consider-using-f-string,duplicate-code
-      - id: pylint
-        name: pylint (test code)
-        description: Run pylint rules on "tests/*.py" files
-        types: [python]
-        files: "^tests/"
-        args:
-          - --disable=missing-docstring,consider-using-f-string,duplicate-code
+      - id: ruff-format
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v6.2.0
+    hooks:
+      - id: reuse

--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -21,19 +21,20 @@ Implementation Notes
 """
 
 # imports
-import sys
-import os
-import stat
-import shutil
-import subprocess
 import fcntl
-import platform
 import fileinput
-import re
+import os
+import platform
 import pwd
+import re
+import shutil
+import stat
+import subprocess
+import sys
 from datetime import datetime
-from clint.textui import colored, prompt
+
 import adafruit_platformdetect
+from clint.textui import colored, prompt
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Python_Shell.git"
@@ -102,9 +103,7 @@ class Shell:
             )
         return prompt.options(message, options)
 
-    def run_command(
-        self, cmd, suppress_message=False, return_output=False, run_as_user=None
-    ):
+    def run_command(self, cmd, suppress_message=False, return_output=False, run_as_user=None):
         """
         Run a shell command and show the output as it runs
         """
@@ -149,22 +148,22 @@ class Shell:
         # arrives split across reads or contains in-place updates ending in
         # ``\r`` (e.g. download progress bars).
         stream_state = {"stdout": True, "stderr": True}
-        with subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn
+        with subprocess.Popen(
             cmd,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
-            preexec_fn=preexec,
+            preexec_fn=preexec,  # noqa: PLW1509  # single-threaded use; see preexec docstring
         ) as proc:
             while proc.poll() is None:
                 err = read_stream(proc.stderr)
-                if err != "" and not suppress_message:
+                if err and not suppress_message:
                     stream_state["stderr"] = self._emit_stream_chunk(
                         err, kind="error", at_line_start=stream_state["stderr"]
                     )
                 output = read_stream(proc.stdout)
-                if output != "" and not suppress_message:
+                if output and not suppress_message:
                     stream_state["stdout"] = self._emit_stream_chunk(
                         output, kind="info", at_line_start=stream_state["stdout"]
                     )
@@ -172,12 +171,12 @@ class Shell:
             # Drain anything that arrived between the last read and the
             # process exit so short-lived commands don't lose their output.
             err = read_stream(proc.stderr)
-            if err != "" and not suppress_message:
+            if err and not suppress_message:
                 stream_state["stderr"] = self._emit_stream_chunk(
                     err, kind="error", at_line_start=stream_state["stderr"]
                 )
             output = read_stream(proc.stdout)
-            if output != "" and not suppress_message:
+            if output and not suppress_message:
                 stream_state["stdout"] = self._emit_stream_chunk(
                     output, kind="info", at_line_start=stream_state["stdout"]
                 )
@@ -273,7 +272,7 @@ class Shell:
             self.error(f"Template file '{template}' does not exist")
             return None
 
-        with open(template, "r") as template_file:
+        with open(template) as template_file:
             template_content = template_file.read()
 
         # Render the template with the provided context
@@ -337,13 +336,13 @@ class Shell:
         if default is None:
             choicebox = "[y/n]"
         else:
-            if default not in ["y", "n"]:
+            if default not in {"y", "n"}:
                 default = "y"
             choicebox = "[Y/n]" if default == "y" else "[y/N]"
         while True:
             reply = input(message + " " + choicebox + " ").strip()
 
-            if reply == "" and default is not None:
+            if not reply and default is not None:
                 return default == "y"
 
             if re.match("y(?:es)?", reply, re.I):
@@ -631,7 +630,7 @@ class Shell:
         path = self.path(path)
         if not os.path.exists(path):
             raise FileNotFoundError(f"File '{path}' does not exist")
-        with open(path, "r", encoding="utf-8") as file:
+        with open(path, encoding="utf-8") as file:
             return file.read()
 
     @staticmethod
@@ -750,9 +749,9 @@ class Shell:
         if version.lower() not in RASPI_VERSIONS:
             raise ValueError("Invalid version")
         # Check that the current version is at least the specified version
-        return RASPI_VERSIONS.index(
-            self.get_raspbian_version()
-        ) >= RASPI_VERSIONS.index(version.lower())
+        return RASPI_VERSIONS.index(self.get_raspbian_version()) >= RASPI_VERSIONS.index(
+            version.lower()
+        )
 
     def prompt_reboot(self, default="y", **kwargs):
         """Prompt the user for a reboot"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
-
 # SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
+import datetime
 import os
 import sys
-import datetime
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -41,9 +39,7 @@ project = "Adafruit Shell Library"
 creation_year = "2020"
 current_year = str(datetime.datetime.now().year)
 year_duration = (
-    current_year
-    if current_year == creation_year
-    else creation_year + " - " + current_year
+    current_year if current_year == creation_year else creation_year + " - " + current_year
 )
 copyright = year_duration + " Melissa LeBlanc-Williams"
 author = "Melissa LeBlanc-Williams"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2024 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+target-version = "py38"
+line-length = 100
+
+[lint]
+preview = true
+select = ["I", "PL", "UP"]
+
+extend-select = [
+  "D419",  # empty-docstring
+  "E501",  # line-too-long
+  "W291",  # trailing-whitespace
+  "PLC0414",  # useless-import-alias
+  "PLC2401",  # non-ascii-name
+  "PLC2801",  # unnecessary-dunder-call
+  "PLC3002",  # unnecessary-direct-lambda-call
+  "PLE0101",  # return-in-init
+  "F706",  # return-outside-function
+  "F704",  # yield-outside-function
+  "PLE0116",  # continue-in-finally
+  "PLE0117",  # nonlocal-without-binding
+  "PLE0241",  # duplicate-bases
+  "PLE0302",  # unexpected-special-method-signature
+  "PLE0604",  # invalid-all-object
+  "PLE0605",  # invalid-all-format
+  "PLE0643",  # potential-index-error
+  "PLE0704",  # misplaced-bare-raise
+  "PLE1141",  # dict-iter-missing-items
+  "PLE1142",  # await-outside-async
+  "PLE1205",  # logging-too-many-args
+  "PLE1206",  # logging-too-few-args
+  "PLE1307",  # bad-string-format-type
+  "PLE1310",  # bad-str-strip-call
+  "PLE1507",  # invalid-envvar-value
+  "PLE2502",  # bidirectional-unicode
+  "PLE2510",  # invalid-character-backspace
+  "PLE2512",  # invalid-character-sub
+  "PLE2513",  # invalid-character-esc
+  "PLE2514",  # invalid-character-nul
+  "PLE2515",  # invalid-character-zero-width-space
+  "PLR0124",  # comparison-with-itself
+  "PLR0202",  # no-classmethod-decorator
+  "PLR0203",  # no-staticmethod-decorator
+  "UP004",  # useless-object-inheritance
+  "PLR0206",  # property-with-parameters
+  "PLR0904",  # too-many-public-methods
+  "PLR0911",  # too-many-return-statements
+  "PLR0912",  # too-many-branches
+  "PLR0913",  # too-many-arguments
+  "PLR0914",  # too-many-locals
+  "PLR0915",  # too-many-statements
+  "PLR0916",  # too-many-boolean-expressions
+  "PLR1702",  # too-many-nested-blocks
+  "PLR1704",  # redefined-argument-from-local
+  "PLR1711",  # useless-return
+  "C416",  # unnecessary-comprehension
+  "PLR1733",  # unnecessary-dict-index-lookup
+  "PLR1736",  # unnecessary-list-index-lookup
+
+  # ruff reports this rule is unstable
+  #"PLR6301",  # no-self-use
+
+  "PLW0108",  # unnecessary-lambda
+  "PLW0120",  # useless-else-on-loop
+  "PLW0127",  # self-assigning-variable
+  "PLW0129",  # assert-on-string-literal
+  "B033",  # duplicate-value
+  "PLW0131",  # named-expr-without-context
+  "PLW0245",  # super-without-brackets
+  "PLW0406",  # import-self
+  "PLW0602",  # global-variable-not-assigned
+  "PLW0603",  # global-statement
+  "PLW0604",  # global-at-module-level
+
+  # fails on the try: import typing used by libraries
+  #"F401",  # unused-import
+
+  "F841",  # unused-variable
+  "E722",  # bare-except
+  "PLW0711",  # binary-op-exception
+  "PLW1501",  # bad-open-mode
+  "PLW1508",  # invalid-envvar-default
+  "PLW1509",  # subprocess-popen-preexec-fn
+  "PLW2101",  # useless-with-lock
+  "PLW3301",  # nested-min-max
+]
+
+ignore = [
+    "PLR2004", # magic-value-comparison
+    "UP030", # format literals
+    "PLW1514",  # unspecified-encoding
+    "PLR0904", # too many public methods
+    "PLR0911", # too many return statements
+    "PLR0912", # too many local branches
+    "PLR0913", # too many arguments
+    "PLR0914", # too many local variables
+    "PLR0915", # too many statements
+    "PLR0917", # too many positional arguments
+    "PLR1702", # too many nested blocks
+    "PLR6301", # Method could be a function, class method, or static method
+]
+
+[format]
+line-ending = "lf"


### PR DESCRIPTION
Closes #34.

Migrates the pre-commit pipeline from `black` + `pylint` to the unified `ruff` (format + lint), matching the convention used by `Adafruit_CircuitPython_Display_Text` and the rest of the CircuitPython library ecosystem.

### `.pre-commit-config.yaml`

- Drop `python/black` v23.3.0
- Drop `pycqa/pylint` v2.17.4 (library / example / test entries)
- Add `astral-sh/ruff-pre-commit` v0.15.8 (`ruff-format` + `ruff --fix`)
- Reorder so `pre-commit-hooks` runs first (matches Display_Text layout)

### `ruff.toml` (new)

- Copied verbatim from [Adafruit_CircuitPython_Display_Text's `ruff.toml`](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/blob/main/ruff.toml) for ecosystem consistency: `target-version = "py38"`, `line-length = 100`, `select = ["I", "PL", "UP"]` plus the per-rule extends.
- Added `PLR0904` (too-many-public-methods) and `PLR0911` (too-many-return-statements) to the `ignore` list because the `Shell` class is a kitchen-sink utility with 65 public methods and multiple-return paths by design; refactoring that out is out of scope for a CI-config migration.

### Code changes (5 trivial cleanups ruff flagged)

Rules: `PLC1901`, `PLR6201`, `UP009`, `UP015`, `I001`.

- `x != ""` → `x` for the four stream-empty checks in `run_command` and one in `prompt()` (`read_stream` returns `""` for "no data", so this is a no-op semantically).
- `in ["y", "n"]` → `in {"y", "n"}` in `prompt()` default normalization.
- Removed the redundant `# -*- coding: utf-8 -*-` magic comment from `docs/conf.py` (Python 3 default).
- Sorted imports in `adafruit_shell.py` and `docs/conf.py`.
- Dropped the now-redundant `"r"` mode in `open(template, "r")`.

### Why

- One tool instead of two — faster CI, fewer pinned versions to drift.
- Ruff tracks new Python stdlib changes promptly; we just hit `pkg_resources` being removed in 3.12+ which broke `reuse-tool v1.1.2` (#33) and would similarly bite the pinned `black 23.3.0` / `pylint v2.17.4` if the runner ever moves past 3.11.

### Verification

Ran `pre-commit run --all-files` inside `python:3.11-slim` (matches the GitHub Actions runner Python):

```
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff format..............................................................Passed
ruff (legacy alias)......................................................Passed
reuse lint...............................................................Passed
```
