### PR TITLE
Make Shell.clear() safe for non-TTY stdout

### DIFF
--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -436,8 +436,24 @@ class Shell:
     @staticmethod
     def clear():
         """
-        Clear the screen
+        Clear the screen.
+
+        On an interactive TTY with a usable ``TERM``, defer to the
+        ``clear`` binary so the user gets a real terminal reset
+        (including scrollback flush where the emulator supports it).
+
+        When stdout isn't a TTY (output piped or redirected, CI, etc.)
+        or ``TERM`` is missing/unknown (``sudo`` with a stripped
+        environment, ``env -i``, ...), do nothing. Clearing has no
+        meaning when there's no screen to clear, and unconditionally
+        shelling out to ``clear`` in those cases prints ncurses'
+        ``'unknown': I need something more specific.`` to stderr.
         """
+        if not sys.stdout.isatty():
+            return
+        term = os.environ.get("TERM", "")
+        if not term or term in {"dumb", "unknown"}:
+            return
         os.system("clear")
 
     @staticmethod


### PR DESCRIPTION
## Summary

`Shell.clear()` currently calls `os.system("clear")` unconditionally. When the
script is invoked from a non-interactive context — output piped or redirected,
`sudo` with a stripped environment, CI runners, an automation/agent harness,
etc. — ncurses' `clear` binary runs with a `TERM` value that its terminfo
database can't resolve, and prints a visible cosmetic error to stderr:

```
'unknown': I need something more specific.
```

That line shows up at the top of installer output for anyone running the
Adafruit installers (e.g. `adafruit-pitft.py`) non-interactively on Debian
Trixie. It's harmless but confusing — it looks like a real error.

## Fix

Treat "clear the screen" as a no-op when there is effectively no screen:

- **stdout is not a TTY** (piped/redirected/CI/agent harness) → return early.
- **`TERM` is missing, `dumb`, or `unknown`** (`sudo env -i`, `sudo` with a
  stripped environment, etc.) even on a real TTY → return early.
- **Interactive TTY with a usable `TERM`** → behavior unchanged: shell out to
  `clear` so the user gets a real terminal reset (including scrollback flush
  where the emulator supports it).

An earlier revision of this PR fell back to emitting the ANSI RIS escape
sequence (`\033c`) on the non-TTY path. That was dropped after review feedback
pointed out it would write control bytes into captured/redirected output. A
no-op is the right answer: there is no screen to clear, so we just don't.

## Testing

Verified locally on Trixie with a small driver that exercises all four guard
branches (monkeypatching `sys.stdout.isatty` and `os.environ["TERM"]`):

| stdout | `TERM` | Result |
| --- | --- | --- |
| not a TTY | (any) | no-op, no calls to `os.system` |
| TTY | unset | no-op |
| TTY | `dumb` | no-op |
| TTY | `unknown` | no-op |
| TTY | `xterm-256color` | `os.system("clear")` (original behavior) |

After applying the fix, the spurious
`'unknown': I need something more specific.` message no longer appears at the
top of installer output when running under non-interactive `sudo`.
