### PR TITLE
Add Shell.run_raspi_config() that no-ops on non-Raspberry-Pi-OS

### DIFF
--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -893,6 +893,30 @@ class Shell:
             else:
                 raise RuntimeError("Unable to continue while mismatch is present.")
 
+    def run_raspi_config(self, args, suppress_message=False, return_output=False, run_as_user=None):
+        """
+        Run a ``raspi-config nonint ...`` command, but only on Raspberry Pi OS.
+
+        ``raspi-config`` is only shipped (and only honored) on Raspberry Pi OS;
+        on other distros (DietPi, Ubuntu, etc.) the binary is absent and the
+        tweak would not apply anyway. On non-Pi-OS systems this method is a
+        no-op that returns ``True`` (or ``""`` when ``return_output=True``)
+        so existing call sites continue to work without producing misleading
+        "command not found" output.
+
+        ``args`` is the part after ``raspi-config nonint`` (e.g. ``"do_spi 0"``).
+        ``suppress_message``, ``return_output``, and ``run_as_user`` are
+        forwarded to :meth:`run_command`.
+        """
+        if not self.is_raspberry_pi_os():
+            return "" if return_output else True
+        return self.run_command(
+            "raspi-config nonint " + args,
+            suppress_message=suppress_message,
+            return_output=return_output,
+            run_as_user=run_as_user,
+        )
+
     def set_window_manager(self, manager):
         """
         Call raspi-config to set a new window manager
@@ -907,9 +931,7 @@ class Shell:
             raise RuntimeError("labwc is not installed")
 
         print(f"Using {manager} as the window manager")
-        if not self.run_command(
-            "sudo raspi-config nonint do_wayland " + WINDOW_MANAGERS[manager.lower()]
-        ):
+        if not self.run_raspi_config("do_wayland " + WINDOW_MANAGERS[manager.lower()]):
             raise RuntimeError("Unable to change window manager")
 
     def get_window_manager(self):


### PR DESCRIPTION
## Summary

`raspi-config` is only shipped (and only honored) on Raspberry Pi OS. The installer scripts in [Raspberry-Pi-Installer-Scripts](https://github.com/adafruit/Raspberry-Pi-Installer-Scripts) shell out to `raspi-config nonint ...` in a bunch of places (adafruit-pitft.py, raspi-blinka.py, raspi-spi-reassign.py, joy-bonnet.py, retrogame.py, pitft-fbcp.py, ...) to toggle SPI/I2C, set overscan, change boot behaviour, etc. On non-Pi-OS distros that share the same hardware (DietPi, Ubuntu Server on a Pi, etc.) the binary just isn't there: `shell.run_command` returns falsy on the missing binary and the script continues, but the tweak silently doesn't happen and the user sees a confusing `command not found` line.

## Change

Adds **`Shell.run_raspi_config(args, suppress_message=False, return_output=False, run_as_user=None)`** as a thin wrapper around `run_command`:

- Returns immediately (`True`, or `""` when `return_output=True`) when `is_raspberry_pi_os()` is False, so callers that ignore the return value short-circuit cleanly and callers that `.strip()` the output still get a usable string.
- On Raspberry Pi OS, forwards to `run_command("raspi-config nonint " + args, ...)` with the same kwargs.

`args` is the portion after `raspi-config nonint` — e.g. `shell.run_raspi_config("do_spi 0")`.

Also migrates the existing `Shell.set_window_manager()` call (which already invokes `raspi-config nonint do_wayland …` directly) to use the new helper. That gives it the same non-Pi-OS short-circuit and avoids the `RuntimeError("Unable to change window manager")` it would otherwise raise on hosts where the binary isn't present.

## Test plan

Installed the modified package in a venv and exercised `run_raspi_config` with `Shell.run_command` monkey-patched to record calls:

| Scenario | Result | `run_command` calls observed |
| --- | --- | --- |
| Pi OS, basic call: `run_raspi_config('do_spi 0')` | returns `True` | `raspi-config nonint do_spi 0` ✓ |
| Pi OS, with `return_output=True, suppress_message=True`: `run_raspi_config('get_spi', suppress_message=True, return_output=True)` | returns subprocess output | `raspi-config nonint get_spi` with all kwargs forwarded ✓ |
| Non-Pi-OS, basic call | returns `True` | none ✓ |
| Non-Pi-OS, `return_output=True` | returns `''` (so `.strip()` callers stay happy) | none ✓ |

## Follow-up

A companion PR against `adafruit/Raspberry-Pi-Installer-Scripts` (#384, currently in flight) will switch the call sites in `adafruit-pitft.py` over to `shell.run_raspi_config(...)` once this lands. Other scripts in that repo (`raspi-blinka.py`, `raspi-spi-reassign.py`, `joy-bonnet.py`, `retrogame.py`, `pitft-fbcp.py`) can migrate the same way.