### PR TITLE
Add Shell.append_if_missing() helper

### DIFF
--- a/adafruit_shell.py
+++ b/adafruit_shell.py
@@ -558,6 +558,14 @@ class Shell:
                 # Not found; append (silently)
                 self.write_text_file(file, replacement, append=True)
 
+    def append_if_missing(self, file, line):
+        """
+        Append an exact line to a file only if it is not already present.
+        Equivalent to the shell idiom: grep -qxF "line" file || echo line >> file
+        """
+        if not self.pattern_search(file, "^" + re.escape(line) + "$"):
+            self.write_text_file(file, line, append=True)
+
     # pylint: disable=too-many-arguments
     def pattern_search(
         self, location, pattern, multi_line=False, return_match=False, find_all=False


### PR DESCRIPTION
Adds `Shell.append_if_missing(file, line)` — the common "add a line only if it isn't already there" idiom that the installer scripts repeat constantly for `/etc/modules`, modprobe blacklists, and `config.txt` entries.

It's the Python equivalent of:

```bash
grep -qxF "line" file || echo line >> file
```

Complements the existing `reconfig()` (which is uncomment-or-append for a regex pattern). `append_if_missing` is for the simpler exact-line case where you just want to guarantee a literal line is present without disturbing anything else.

Uses `re.escape` so lines containing regex metacharacters (e.g. `dtoverlay=i2s-mmap`) are matched literally rather than as patterns.

### Context
Suggested by @makermelissa on adafruit/Raspberry-Pi-Installer-Scripts#398, where several converted installers each define a private copy of this helper. Landing it here lets those scripts share one implementation.

### Testing
- `ruff format` + `ruff check` + `reuse lint` (pre-commit) all pass.
- Manually verified: no duplicate when the line is already present (anywhere in the file), appends when absent, and metacharacter-containing lines dedup correctly.